### PR TITLE
ci: bump CI to Go 1.25 to match go.mod requirement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: '1.24'
-  GOLANGCI_LINT_VERSION: 'v2.1.6'
+  GO_VERSION: '1.25'
+  GOLANGCI_LINT_VERSION: 'v2.4.0'
 
 jobs:
   lint:
@@ -55,7 +55,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go: ['1.24']
+        go: ['1.25']
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
@@ -91,7 +91,7 @@ jobs:
           CGO_ENABLED: 1
 
       - name: Upload coverage to Codecov
-        if: matrix.os == 'ubuntu-latest' && matrix.go == '1.24'
+        if: matrix.os == 'ubuntu-latest' && matrix.go == '1.25'
         uses: codecov/codecov-action@v5
         with:
           file: ./coverage.out

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,10 @@ jobs:
 
       - name: Run integration tests
         run: |
-          sudo -E go test -v -timeout=2m -tags=integration ./test/integration/...
+          # sudo resets PATH to secure_path, which resolves the runner's
+          # pre-installed Go instead of the setup-go toolchain. Force the
+          # user's PATH so `go` matches GO_VERSION (go.mod requires >= 1.25).
+          sudo -E env "PATH=$PATH" go test -v -timeout=2m -tags=integration ./test/integration/...
         env:
           CGO_ENABLED: 1
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.24'
+        go-version: '1.25'
         cache: true
 
     - name: Install dependencies

--- a/.github/workflows/release-all-platforms.yml
+++ b/.github/workflows/release-all-platforms.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.25'
       
       - name: Install dependencies
         run: |
@@ -119,7 +119,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.25'
       
       - name: Install cross-compilation tools
         run: |
@@ -216,7 +216,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.25'
       
       - name: Build
         run: |
@@ -285,7 +285,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.25'
       
       - name: Install dependencies
         run: |
@@ -330,7 +330,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.25'
       
       - name: Install dependencies
         run: |
@@ -384,7 +384,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.25'
       
       - name: Build
         shell: pwsh

--- a/.github/workflows/release-native.yml
+++ b/.github/workflows/release-native.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.25'
       
       - name: Install dependencies
         run: |
@@ -72,7 +72,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.25'
       
       - name: Install dependencies
         run: |
@@ -124,7 +124,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.25'
       
       - name: Install dependencies
         run: |
@@ -176,7 +176,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.25'
       
       - name: Install dependencies
         run: |
@@ -312,7 +312,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.25'
       
       - name: Install dependencies
         run: |

--- a/.github/workflows/release-simple.yml
+++ b/.github/workflows/release-simple.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.25'
       
       - name: Install dependencies
         run: |
@@ -75,7 +75,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.25'
       
       - name: Install dependencies
         run: |
@@ -127,7 +127,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.25'
       
       - name: Install dependencies
         run: |

--- a/.github/workflows/release-universal-simple.yml
+++ b/.github/workflows/release-universal-simple.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.25'
       
       - name: Install dependencies (Linux)
         if: matrix.goos == 'linux'

--- a/pkg/ui/ui_bench_test.go
+++ b/pkg/ui/ui_bench_test.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"fmt"
 	"net"
+	"sync/atomic"
 	"testing"
 	"time"
 	
@@ -375,10 +376,17 @@ func BenchmarkConcurrentUIUpdates(b *testing.B) {
 		b.Run(fmt.Sprintf("Workers-%d", numWorkers), func(b *testing.B) {
 			monitor := netcap.NewNetworkMonitor()
 			ui := NewUI(monitor)
-			
+
+			// Pre-create the interface entry once so the parallel workers
+			// never write the shared map concurrently (Go maps are not safe
+			// for concurrent writes). Concurrent reads of the populated map
+			// and atomic updates to the counters below are race-free.
+			stats := &netcap.InterfaceStats{}
+			monitor.Interfaces["test0"] = stats
+
 			b.ResetTimer()
 			b.ReportAllocs()
-			
+
 			b.RunParallel(func(pb *testing.PB) {
 				i := 0
 				for pb.Next() {
@@ -392,10 +400,8 @@ func BenchmarkConcurrentUIUpdates(b *testing.B) {
 						ui.SetGradientEnabled(i%2 == 0)
 					case 3:
 						// Simulate traffic update
-						monitor.Interfaces["test0"] = &netcap.InterfaceStats{
-							BytesIn:  uint64(i * 1000),
-							BytesOut: uint64(i * 500),
-						}
+						atomic.StoreUint64(&stats.BytesIn, uint64(i*1000))
+						atomic.StoreUint64(&stats.BytesOut, uint64(i*500))
 					}
 					i++
 				}


### PR DESCRIPTION
## Problem

`main`'s CI has been red since 2026-04-29. Every open Dependabot PR (#52, #54, #56, #57, #58, #60, #61, #62) fails its checks for the **same root cause**, not because of the dependency bumps themselves.

Since #59 bumped `golang.org/x/image` to 0.38.0, `go.mod` requires `go 1.25.0`, but every CI job pinned Go **1.24**. With `GOTOOLCHAIN=local`, Go refuses to run:

```
go: go.mod requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)
```

That single mismatch cascades into every failing check:

| Check | Why it failed |
|-------|---------------|
| Test (all 3 OS) | `go test` refuses to run under 1.24 |
| Lint | `go vet` / `go mod tidy` refuse to run; golangci-lint v2.1.6 (built with go1.24) can't load config against a 1.25 target (`exit code 3`) |
| Benchmark | `go test -bench` refuses to run (`needs: [test]`) |
| Security Scan | gosec / govulncheck run `go` under the hood (`needs: [test]`) |

## Fix

Match the toolchain to `go.mod`:

- `GO_VERSION` and the test matrix → `1.25`
- `GOLANGCI_LINT_VERSION` → `v2.4.0` (the minimal golangci-lint release built with go1.25)

`x/image@0.38.0` and `x/text@0.35.0` genuinely require Go 1.25, so bumping the toolchain (rather than downgrading `go.mod` + holding those deps back) is the low-friction fix that keeps working *with* Dependabot.

## Verification

Locally under a ≥1.25 toolchain:
- `go vet ./...` → exit 0
- `go mod tidy` → no diff (the Lint job's tidy check passes)
- `go build ./...` → clean

Once merged, the 8 Dependabot PRs will be rebased to pick up the fixed CI.

https://claude.ai/code/session_01VbmRaTdo3Xc4oqB9Fo1YQB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI and release GitHub workflows to use Go 1.25 instead of 1.24.
  * Upgraded the CI linting tool to a newer pinned version.
  * Adjusted the test matrix and Codecov upload condition to align with the Go 1.25 change.
  * Updated the CodeQL workflow to run with Go 1.25.

* **Tests**
  * Improved the concurrent UI benchmark to avoid unsafe parallel map/counter updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->