### PR TITLE
ci: stop Benchmark job from failing PRs on noise

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,10 @@ jobs:
           go test -bench=. -benchmem -run=^$ ./... | tee benchmark.txt
 
       - name: Ensure gh-pages branch exists
+        # Only push benchmark history on pushes to the repo's own branches.
+        # On pull_request events (esp. Dependabot) the GITHUB_TOKEN is
+        # read-only, so pushing gh-pages / commenting alerts fails.
+        if: github.event_name == 'push'
         run: |
           if ! git ls-remote --heads origin gh-pages | grep -q gh-pages; then
             current_sha=$(git rev-parse HEAD)
@@ -169,6 +173,9 @@ jobs:
           fi
 
       - name: Store benchmark result
+        # Push events only: PRs lack write access, and the sub-nanosecond
+        # benchmarks here are too noisy for a hard fail-on-alert gate.
+        if: github.event_name == 'push'
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: Go Benchmark
@@ -178,7 +185,7 @@ jobs:
           auto-push: true
           alert-threshold: '200%'
           comment-on-alert: true
-          fail-on-alert: true
+          fail-on-alert: false
 
   security:
     name: Security Scan


### PR DESCRIPTION
## Problem

The `Benchmark` job failed intermittently on PRs — every Dependabot PR in this batch (#57, #58, #61, #62) went red on it — for two coupled reasons, neither related to the PRs' actual changes:

1. **Noise trips the gate.** Sub-nanosecond benchmarks (theme ops, braille generation) swing widely on shared CI runners. A `0.3ns → 0.7ns` blip counts as "2.3× worse", exceeding `alert-threshold: 200%` with `fail-on-alert: true`.
2. **Dependabot's token can't comment.** When the alert fires, `comment-on-alert: true` posts via `GITHUB_TOKEN`, which is **read-only on `pull_request` events** (Dependabot) → `Resource not accessible by integration` → job fails.

`Benchmark` isn't a required check, but the spurious red is noise and can also redden `main`.

## Fix

- Gate the **Ensure gh-pages** and **Store benchmark result** steps to `if: github.event_name == 'push'`. PRs still **run** benchmarks (so a real crash/compile error — like the concurrent-map-write fixed in #63 — still fails the PR), but skip the gh-pages push + alert-comment path that needs write access.
- Set `fail-on-alert: false` so noisy runs on `main` record history without breaking CI.

## Effect

- PRs: benchmarks run, no push/alert, no false red.
- `main`/`develop` pushes: history stored to gh-pages, alerts commented for visibility, never a hard fail on jitter.

https://claude.ai/code/session_01VbmRaTdo3Xc4oqB9Fo1YQB